### PR TITLE
Add environment-based configuration defaults

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,28 @@
+# Secure Image Processing Pipeline configuration
+# Adjust these values to customise the interactive defaults.
+
+# Base project directory (defaults to repository root)
+PIPELINE_BASE_DIR=.
+
+# Directory names used by the pipeline
+PIPELINE_INGEST_DIR=ingest
+PIPELINE_CLEAN_DIR=clean
+PIPELINE_ORIGINALS_DIR=originals
+PIPELINE_DB_DIR=db
+PIPELINE_LOG_DIR=logs
+
+# Database filename stored in the database directory
+PIPELINE_DB_FILENAME=processing.db
+
+# Default operator metadata
+PIPELINE_DEFAULT_OPERATOR=operator_1
+PIPELINE_DEFAULT_SECURITY_LEVEL=2
+
+# Obfuscation defaults (can be overridden interactively)
+PIPELINE_LSB_FLIP_PROBABILITY=0.20
+PIPELINE_OBFUSCATION_PASSES=3
+PIPELINE_ADD_NOISE=true
+
+# Output format defaults
+PIPELINE_OUTPUT_FORMAT=JPEG
+PIPELINE_JPEG_QUALITY=85


### PR DESCRIPTION
## Summary
- load pipeline configuration defaults from a new `.env` file and hydrate environment variables at startup
- update the secure pipeline to honour environment-driven directory paths and processing defaults
- align the setup utility with the `.env` configuration so initialisation and database creation follow the same settings

## Testing
- python -m compileall main.py src

------
https://chatgpt.com/codex/tasks/task_e_68d3c096494c8324bccdb032e4eb3ffe