### PR TITLE
Fix secure randomness and metadata extraction

### DIFF
--- a/src/SecureImageProcessor.py
+++ b/src/SecureImageProcessor.py
@@ -8,9 +8,11 @@ from pathlib import Path
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Tuple
 import time
+import secrets
 
 # Image processing imports
 from PIL import Image, ImageFilter, ImageEnhance
+from PIL import ExifTags
 from PIL.ExifTags import TAGS, GPSTAGS
 import numpy as np
 import random
@@ -22,6 +24,13 @@ class SecureImageProcessor:
     def __init__(self, config: Dict):
         self.config = config
         self.secure_random = random.SystemRandom()
+
+    @staticmethod
+    def _serialize_metadata_value(value) -> str:
+        """Convert metadata values to a JSON-serializable representation."""
+        if isinstance(value, (bytes, bytearray)):
+            return f"<{len(value)} bytes>"
+        return str(value)
 
     def extract_all_metadata(self, img: Image.Image) -> Dict:
         """Extract comprehensive metadata for preservation."""
@@ -40,15 +49,62 @@ class SecureImageProcessor:
             if exif:
                 for tag_id, value in exif.items():
                     tag = TAGS.get(tag_id, tag_id)
-                    # Handle GPS data separately
-                    if tag == 'GPSInfo':
+                    if tag == 'GPSInfo' and isinstance(value, dict):
                         gps_data = {}
                         for gps_tag_id, gps_value in value.items():
                             gps_tag = GPSTAGS.get(gps_tag_id, gps_tag_id)
-                            gps_data[gps_tag] = str(gps_value)
+                            gps_data[gps_tag] = self._serialize_metadata_value(gps_value)
                         metadata['exif_gps'] = gps_data
                     else:
-                        metadata['exif_data'][tag] = str(value)
+                        metadata['exif_data'][str(tag)] = self._serialize_metadata_value(value)
+
+                if hasattr(exif, "get_ifd"):
+                    ifd_map = getattr(ExifTags, "IFD", None)
+                    if ifd_map:
+                        if hasattr(ifd_map, "items"):
+                            ifd_iterable = ifd_map.items()
+                        elif hasattr(ifd_map, "__members__"):
+                            ifd_iterable = ifd_map.__members__.items()
+                        else:
+                            ifd_iterable = []
+
+                        for ifd_name, ifd_value in ifd_iterable:
+                            if hasattr(ifd_value, "value"):
+                                ifd_id = ifd_value.value
+                            else:
+                                ifd_id = ifd_value
+
+                            try:
+                                ifd = exif.get_ifd(ifd_id)
+                            except (KeyError, AttributeError, TypeError):
+                                continue
+
+                            if not ifd:
+                                continue
+
+                            formatted_ifd = {}
+                            for nested_tag_id, nested_value in ifd.items():
+                                tag_name = TAGS.get(nested_tag_id, f"Unknown_{nested_tag_id}")
+                                formatted_ifd[tag_name] = self._serialize_metadata_value(nested_value)
+
+                            if formatted_ifd:
+                                metadata['exif_data'][f"{ifd_name}_IFD"] = formatted_ifd
+
+                maker_note_tag = None
+                tags_v2 = getattr(ExifTags, "TAGS_V2", None)
+                if isinstance(tags_v2, dict):
+                    maker_note_tag = tags_v2.get('MakerNote')
+
+                if maker_note_tag is None:
+                    for tag_id, tag_name in TAGS.items():
+                        if tag_name == 'MakerNote':
+                            maker_note_tag = tag_id
+                            break
+
+                if maker_note_tag is not None:
+                    maker_note_value = exif.get(maker_note_tag)
+                    if maker_note_value:
+                        metadata['exif_data']['MakerNote'] = self._serialize_metadata_value(maker_note_value)
         except Exception as e:
             metadata['exif_extraction_error'] = str(e)
 
@@ -119,24 +175,32 @@ class SecureImageProcessor:
 
     def _randomize_lsb_bits(self, img_array: np.ndarray, flip_probability: float) -> np.ndarray:
         """Randomly flip least significant bits."""
+        if img_array.size == 0:
+            return img_array
+
+        prob = max(0.0, min(1.0, float(flip_probability)))
+        if prob <= 0.0:
+            return img_array.astype(np.uint8)
+        if prob >= 1.0:
+            return (img_array ^ 1).astype(np.uint8)
+
         height, width, channels = img_array.shape
+        threshold = int(prob * 256)
+        random_bytes = secrets.token_bytes(img_array.size)
+        random_values = np.frombuffer(random_bytes, dtype=np.uint8).reshape(height, width, channels)
+        flip_mask = random_values < threshold
 
-        # Generate random mask
-        flip_mask = self.secure_random.choices(
-            [0, 1],
-            weights=[1 - flip_probability, flip_probability],
-            k=height * width * channels
-        )
-        flip_mask = np.array(flip_mask).reshape(height, width, channels)
-
-        # Apply LSB flipping
-        lsb_mask = np.ones_like(img_array, dtype=np.uint8)
-        result = np.where(flip_mask, img_array ^ lsb_mask, img_array)
-
+        result = np.where(flip_mask, img_array ^ 1, img_array)
         return result.astype(np.uint8)
 
     def _add_subtle_noise(self, img_array: np.ndarray, noise_level: float) -> np.ndarray:
         """Add subtle noise to disrupt patterns."""
-        noise = np.random.normal(0, noise_level, img_array.shape)
+        if img_array.size == 0 or noise_level <= 0:
+            return img_array.astype(np.uint8)
+
+        noise_bytes = secrets.token_bytes(img_array.size)
+        noise_array = np.frombuffer(noise_bytes, dtype=np.uint8).reshape(img_array.shape)
+        noise = (noise_array.astype(np.float32) - 127.5) * (float(noise_level) / 127.5)
         noisy = img_array.astype(np.float32) + noise
         return np.clip(noisy, 0, 255).astype(np.uint8)
+


### PR DESCRIPTION
## Summary
- replace pseudorandom LSB flipping and noise generation with secrets-based randomness
- enhance metadata extraction to walk nested EXIF IFDs and MakerNote entries

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d3d01a97e8832485aacf4586c070c1